### PR TITLE
Replace deprecated PHP short open tags

### DIFF
--- a/views/auth-error.php
+++ b/views/auth-error.php
@@ -8,9 +8,9 @@
   <div class="ui error message">
     <div class="header"><?= $this->e($error) ?></div>
     <p><?= $this->e($error_description) ?></p>
-    <? if(isset($error_debug)): ?>
+    <?php if(isset($error_debug)): ?>
       <pre class="small"><?= $error_debug ?></pre>
-    <? endif; ?>
+    <?php endif; ?>
     <a href="<?= is_logged_in() ? '/' : '/' ?>">Start Over</a>
   </div>
 

--- a/views/hub/feed-txt.php
+++ b/views/hub/feed-txt.php
@@ -1,11 +1,11 @@
 <?= $title."\n" ?>
 =============
 
-<? foreach($posts as $i=>$post): ?>
+<?php foreach($posts as $i=>$post): ?>
 <?= html_entity_decode($post['content']) ?>
 
 by <?= $post['author'] ?>
 on <?= date('F j, Y g:ia', strtotime($post['published'])) ?>  
 
-<? endforeach ?>
+<?php endforeach ?>
 

--- a/views/hub/feed.php
+++ b/views/hub/feed.php
@@ -7,7 +7,7 @@
 
   <div id="subscriber-post-list" class="h-feed">
     <span class="p-name hidden">WebSub.rocks Test <?= $num ?></span>
-    <? $this->insert('subscriber/post-list', ['posts'=>$posts, 'num'=>$num]) ?>
+    <?php $this->insert('subscriber/post-list', ['posts'=>$posts, 'num'=>$num]) ?>
   </div>
 
 </div>

--- a/views/index.php
+++ b/views/index.php
@@ -8,14 +8,14 @@
     <p><b><i>WebSub Rocks!</i></b> is a validator to help you test your <a href="https://www.w3.org/TR/websub/">WebSub</a> implementation. Several kinds of tests are available on the site.</p>
   </section>
 
-  <? if(p3k\flash('login')): ?>
+  <?php if(p3k\flash('login')): ?>
     <div class="ui success message">
       <div class="header">Welcome!</div>
       <p>You are logged in as <?= $_SESSION['email'] ?? 'unknown' ?>!</p>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if(!is_logged_in()): ?>
+  <?php if(!is_logged_in()): ?>
     <section class="content">
       <h3>Sign in to begin</h3>
 
@@ -29,7 +29,7 @@
 
       <p>You will receive an email with a link to sign in.</p>
     </section>
-  <? endif; ?>
+  <?php endif; ?>
 
   <section class="content">
     <h2>Roles</h2>

--- a/views/subscriber/feed-3xx.php
+++ b/views/subscriber/feed-3xx.php
@@ -19,7 +19,7 @@
 
   <div id="subscriber-post-list" class="h-feed">
     <span class="p-name hidden">WebSub.rocks Test <?= $num ?></span>
-    <? $this->insert('subscriber/post-list', ['posts'=>$posts, 'num'=>$num]) ?>
+    <?php $this->insert('subscriber/post-list', ['posts'=>$posts, 'num'=>$num]) ?>
   </div>
 
 </div>

--- a/views/subscriber/feed-atom.php
+++ b/views/subscriber/feed-atom.php
@@ -11,7 +11,7 @@
 
   <subtitle>This Atom feed has a stylesheet that will make it look like the websub.rocks site. If you are seeing this message, your browser doesn't support XSLT. To add a new post to this feed, follow this link <?= Config::$base ?>subscriber/<?= $num ?>/<?= $token ?>/publish</subtitle>
 
-  <? foreach($posts as $i=>$post): ?>
+  <?php foreach($posts as $i=>$post): ?>
 
   <entry>
     <id><?= $self ?>#quote-<?= $i ?></id>
@@ -24,5 +24,5 @@
     </author>
   </entry>
 
-  <? endforeach ?>
+  <?php endforeach ?>
 </feed>

--- a/views/subscriber/feed-rss.php
+++ b/views/subscriber/feed-rss.php
@@ -16,7 +16,7 @@
 
   <description>This RSS feed has a stylesheet that will make it look like the websub.rocks site. If you are seeing this message, your browser doesn't support XSLT. To add a new post to this feed, follow this link <?= Config::$base ?>subscriber/<?= $num ?>/<?= $token ?>/publish</description>
 
-  <? foreach($posts as $i=>$post): ?>
+  <?php foreach($posts as $i=>$post): ?>
 
     <item>
       <title></title>
@@ -27,6 +27,6 @@
       <author><?= $post['author'] ?></author>
     </item>
     
-  <? endforeach ?>
+  <?php endforeach ?>
 </channel>
 </rss>

--- a/views/subscriber/feed.php
+++ b/views/subscriber/feed.php
@@ -15,7 +15,7 @@
 
   <div id="subscriber-post-list" class="h-feed">
     <span class="p-name hidden">WebSub.rocks Test <?= $num ?></span>
-    <? $this->insert('subscriber/post-list', ['posts'=>$posts, 'num'=>$num]) ?>
+    <?php $this->insert('subscriber/post-list', ['posts'=>$posts, 'num'=>$num]) ?>
   </div>
 
 </div>

--- a/views/subscriber/post-list.php
+++ b/views/subscriber/post-list.php
@@ -1,4 +1,4 @@
-  <? foreach($posts as $i=>$post): ?>
+  <?php foreach($posts as $i=>$post): ?>
 
     <section class="content h-entry" id="quote-<?= $i ?>">
       <div class="e-content p-name"><?= $post['content'] ?></div>
@@ -10,4 +10,4 @@
       </a>
     </section>
     
-  <? endforeach ?>
+  <?php endforeach ?>


### PR DESCRIPTION
So far this is the only thing I've had to change to get this working in a Debian bullseye container (PHP 7.4). I'm only testing a Subscriber, and I'm less than half done implementing, so I expect to find other problems eventually. I could have turned on short open tags instead, but all the documentation I read says it's not a good idea for production code.