### PR TITLE
fix #25 (error 500 when creating new post)

### DIFF
--- a/lib/Rocks/Hub.php
+++ b/lib/Rocks/Hub.php
@@ -137,7 +137,7 @@ class Hub {
     );
 
     $route = new \App\Subscriber();
-    $feed = $route->get_feed($request, $response, ['num'=>$num, 'token'=>$token]);
+    $feed = $route->get_feed($request, ['num'=>$num, 'token'=>$token]);
     $html = $feed->getBody();
 
     return (string)$html;


### PR DESCRIPTION
This bug was introduced in 07ef450 when the signature of get_feed was changed, but this call to it was not.