### PR TITLE
Correct descriptions of Subscriber tests 203, 204

### DIFF
--- a/views/subscriber/index.php
+++ b/views/subscriber/index.php
@@ -56,12 +56,12 @@
       <tr>
         <td></td>
         <td><a href="/subscriber/203">203</a></td>
-        <td>Subscribing to a hub that sends a 302 temporary redirect</td>
+        <td>Subscribing to a hub that sends a 307 temporary redirect</td>
       </tr>
       <tr>
         <td></td>
         <td><a href="/subscriber/204">204</a></td>
-        <td>Subscribing to a hub that sends a 301 permanent redirect</td>
+        <td>Subscribing to a hub that sends a 308 permanent redirect</td>
       </tr>
       <tr>
         <td></td>


### PR DESCRIPTION
The tests themselves are correct, sending 307 and 308 status codes,
respectively, but the descriptions at `/subscriber` incorrectly
described them as sending 302 and 301 status codes. The spec requires
handling 307 and 308, which is correct because both the original call
and the redirected call should be POST.